### PR TITLE
Add filter to filter post_type's before query is executed

### DIFF
--- a/contextual-related-posts.php
+++ b/contextual-related-posts.php
@@ -413,6 +413,16 @@ function get_crp_posts_id( $args = array() ) {
 
 	parse_str( $post_types, $post_types );	// Save post types in $post_types variable
 
+	/**
+	 * Filter the post_types to filter by.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param array  $post_types  Array of post types to filter by
+	 * @param int    $post->ID    Post ID
+	 */
+	$post_types = apply_filters( 'crp_posts_post_types', $post_types, $post->ID );
+
 	// Are we matching only the title or the post content as well?
 	if( $match_content ) {
 		$stuff = $post->post_title . ' ' . crp_excerpt( $post->ID, $match_content_words, false );


### PR DESCRIPTION
This filter makes it easy to modify the post types to filter by.  I have a page where I need to make multiple related posts calls for different types of data and needed an easier way to control CRP.

While I could (and was) using the `crp_posts_where` filter, I didn't want to do any string processing to modify the SQL and I didn't like just adding another `AND` to the query.