### PR TITLE
Insert after nth paragraph

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -66,6 +66,7 @@ function crp_options() {
 		$crp_settings['add_to_archives'] = ( isset( $_POST['add_to_archives'] ) ? true : false );
 
 		$crp_settings['content_filter_priority'] = absint( $_POST['content_filter_priority'] );
+		$crp_settings['insert_after_paragraph'] = ( -1 === $_POST['insert_after_paragraph'] || '' === $_POST['insert_after_paragraph'] ) ? -1 : intval( $_POST['insert_after_paragraph'] );
 		$crp_settings['show_metabox'] = ( isset( $_POST['show_metabox'] ) ? true : false );
 		$crp_settings['show_metabox_admins'] = ( isset( $_POST['show_metabox_admins'] ) ? true : false );
 		$crp_settings['show_credit'] = ( isset( $_POST['show_credit'] ) ? true : false );

--- a/admin/main-view.php
+++ b/admin/main-view.php
@@ -91,9 +91,16 @@ if ( ! defined( 'WPINC' ) ) {
 
 				<tr><th scope="row"><label for="content_filter_priority"><?php esc_html_e( 'Display location priority:', 'contextual-related-posts' ); ?></label></th>
 					<td>
-						<input type="textbox" name="content_filter_priority" id="content_filter_priority" value="<?php echo esc_attr( stripslashes( $crp_settings['content_filter_priority'] ) ); ?>" />
+						<input type="textbox" name="content_filter_priority" id="content_filter_priority" value="<?php echo esc_attr( $crp_settings['content_filter_priority'] ); ?>" />
 						<p class="description"><?php esc_html_e( 'If you select to automatically add the related posts, CRP will hook into the Content Filter at a priority as specified in this option.', 'contextual-related-posts' ); ?></p>
 						<p class="description"><?php esc_html_e( 'A higher number will cause the related posts to be processed later and move their display further down after the post content. Any number below 10 is not recommended.', 'contextual-related-posts' ); ?></p>
+					</td>
+				</tr>
+
+				<tr><th scope="row"><label for="insert_after_paragraph"><?php esc_html_e( 'Insert after paragraph number', 'contextual-related-posts' ); ?>:</label></th>
+					<td>
+						<input type="textbox" name="insert_after_paragraph" id="insert_after_paragraph" value="<?php echo esc_attr( $crp_settings['insert_after_paragraph'] ); ?>" />
+						<p class="description"><?php esc_html_e( 'Enter 0 to display the related posts before the post content, -1 to display this at the end or a number to insert it after that paragraph number. If your post has less paragraphs, related posts will be displayed at the end.', 'contextual-related-posts' ); ?></p>
 					</td>
 				</tr>
 

--- a/readme.txt
+++ b/readme.txt
@@ -183,6 +183,7 @@ In addition to the above, the shortcode takes every option that the plugin suppo
 * Features:
 	* Shortcode and the widget now have an added parameter for 'offset'. This is useful if you would like to display different widgets/shortcodes but not always start from the first post
 	* New option in metabox: "Exclude this post from the related posts list"
+	* New option: Insert after nth paragraph
 
 * Enhancements:
 	* The generated HTML code uses a single `a href` tag rather than two separate ones per item which is usually better for SEO. If you're not using the Rounded Thumbnail style and using your own custom style, then you might need to reconfigure this


### PR DESCRIPTION
New option to insert the related posts after the "nth" paragraph.

In the settngs, enter 
- 0 to display the related posts before the post content
-1 to display this at the end, or 
- a number to insert it after that paragraph number

If your post has less paragraphs, related posts will be displayed at the end
