### PR TITLE
prevent errors from non-existent post id (virtual post)

### DIFF
--- a/includes/main-query.php
+++ b/includes/main-query.php
@@ -288,6 +288,10 @@ function get_crp_posts_id( $args = array() ) {
 
 	$source_post = ( empty( $args['postid'] ) ) ? $post : get_post( $args['postid'] );
 
+	if ( ! $source_post ) {
+		$source_post = $post;
+	}
+
 	$limit  = ( $args['strict_limit'] ) ? $args['limit'] : ( $args['limit'] * 3 );
 	$offset = isset( $args['offset'] ) ? $args['offset'] : 0;
 

--- a/includes/tools.php
+++ b/includes/tools.php
@@ -22,11 +22,14 @@
 function crp_excerpt( $id, $excerpt_length = 0, $use_excerpt = true ) {
 	$content = '';
 
-	if ( $use_excerpt ) {
-		$content = get_post( $id )->post_excerpt;
-	}
-	if ( empty( $content ) ) {
-		$content = get_post( $id )->post_content;
+	$post = get_post( $id );
+	if ( $post ) {
+		if ( $use_excerpt ) {
+			$content = $post->post_excerpt;
+		}
+		if ( empty( $content ) ) {
+			$content = $post->post_content;
+		}
 	}
 
 	$output = strip_tags( strip_shortcodes( $content ) );


### PR DESCRIPTION
This prevents some php notices when using the plugin with virtual post id's (eg. subscribe to comments reloaded plugin does this for it's management/settings pages).