### PR TITLE
Do not restrict daily_range settings when set to zero

### DIFF
--- a/includes/class-crp-query.php
+++ b/includes/class-crp-query.php
@@ -287,13 +287,15 @@ if ( ! class_exists( 'CRP_Query' ) ) :
 			$args['post_type'] = apply_filters( 'crp_posts_post_types', $post_types, $source_post, $args );
 
 			// Set date_query.
-			$args['date_query'] = array(
-				array(
-					'after'     => ( 0 === absint( $args['daily_range'] ) ) ? '' : gmdate( 'Y-m-d', strtotime( current_time( 'mysql' ) ) - ( absint( $args['daily_range'] ) * DAY_IN_SECONDS ) ),
-					'before'    => current_time( 'mysql' ),
-					'inclusive' => true,
-				),
-			);
+			if ($args['daily_range'] > 0) {
+				$args['date_query'] = array(
+					array(
+						'after'     => ( 0 === absint( $args['daily_range'] ) ) ? '' : gmdate( 'Y-m-d', strtotime( current_time( 'mysql' ) ) - ( absint( $args['daily_range'] ) * DAY_IN_SECONDS ) ),
+						'before'    => current_time( 'mysql' ),
+						'inclusive' => true,
+					),
+				);
+			}
 
 			// Set post_status.
 			$args['post_status'] = empty( $args['post_status'] ) ? array( 'publish', 'inherit' ) : $args['post_status'];


### PR DESCRIPTION
The settings page says the value:
This sets the cut-off period for which posts will be displayed. e.g. setting it to 365 will show related posts from the last year only. **Set to 0 to disable limiting posts by date.**.

But actually when I set to `0`, it requests only 0-day posts.