### PR TITLE
Do not include invalid css

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -55,9 +55,11 @@ function crp_heading_styles() {
 		$style     = $style_array['name'];
 		$extra_css = $style_array['extra_css'];
 
-		wp_register_style( "crp-style-{$style}", plugins_url( "css/{$style}.min.css", CRP_PLUGIN_FILE ), array(), '1.0' );
-		wp_enqueue_style( "crp-style-{$style}" );
-		wp_add_inline_style( "crp-style-{$style}", $extra_css );
+		if ( ! empty ( $style ) ) {
+			wp_register_style( "crp-style-{$style}", plugins_url( "css/{$style}.min.css", CRP_PLUGIN_FILE ), array(), '1.0' );
+			wp_enqueue_style( "crp-style-{$style}" );
+			wp_add_inline_style( "crp-style-{$style}", $extra_css );
+		}
 	}
 }
 add_action( 'wp_enqueue_scripts', 'crp_heading_styles' );


### PR DESCRIPTION
As I see `crp_get_style` will never return an empty array anymore (expected at the line 54), but it returns an array with empty `name` and `extra_css` keys.